### PR TITLE
Stop catching errors on compiling ejs files

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -32,29 +32,25 @@ function ViteEjsPlugin(data: ViteEjsPluginDataType = {}, options?: ViteEjsPlugin
         transformIndexHtml: {
             enforce: "pre",
             transform(html) {
-                try {
-                    if (typeof data === "function") data = data(config);
-                    let ejsOptions = options && options.ejs ? options.ejs : {};
-                    if (typeof ejsOptions === "function") ejsOptions = ejsOptions(config);
+                if (typeof data === "function") data = data(config);
+                let ejsOptions = options && options.ejs ? options.ejs : {};
+                if (typeof ejsOptions === "function") ejsOptions = ejsOptions(config);
 
 
-                    html = ejs.render(
-                        html,
-                        {
-                            NODE_ENV: config.mode,
-                            isDev: config.mode === "development",
-                            ...data
-                        },
-                        {
-                            // setting views enables includes support
-                            views: [config.root],
-                            ...ejsOptions,
-                            async: false // Force sync
-                        }
-                    );
-                } catch (e: any) {
-                    return e.message;
-                }
+                html = ejs.render(
+                    html,
+                    {
+                        NODE_ENV: config.mode,
+                        isDev: config.mode === "development",
+                        ...data
+                    },
+                    {
+                        // setting views enables includes support
+                        views: [config.root],
+                        ...ejsOptions,
+                        async: false // Force sync
+                    }
+                );
 
                 return html;
             }


### PR DESCRIPTION
Current code treats an error message of ejs as a rendered content. This causes unreadable errors on logs.
This pull request removes the code to catch errors to fix that behavior.

# Difference of errors
https://github.com/sunnyone/vite-plugin-ejs-error-sample/blob/master/index.html

## Before
```
$ yarn build
yarn run v1.22.19
$ tsc && vite build
vite v3.2.3 building for production...
✓ 0 modules transformed.
[vite:build-html] Unable to parse HTML; parse5 error code invalid-first-character-of-tag-name
 at {"file":"/home/yoichi/proj/vite-plugin-ejs-error-sample/index.html","line":4,"column":14}
2  |      8|   </head>
3  |      9|   <body>
4  |   >> 10|     <% something_invalid_content %>
   |               ^
5  |      11|     <div id="app"></div>
6  |      12|     <script type="module" src="/src/main.ts"></script>
file: /home/yoichi/proj/vite-plugin-ejs-error-sample/index.html
error during build:
Error: Unable to parse HTML; parse5 error code invalid-first-character-of-tag-name
 at {"file":"/home/yoichi/proj/vite-plugin-ejs-error-sample/index.html","line":4,"column":14}
2  |      8|   </head>
3  |      9|   <body>
4  |   >> 10|     <% something_invalid_content %>
   |               ^
5  |      11|     <div id="app"></div>
6  |      12|     <script type="module" src="/src/main.ts"></script>
    at handleParseError (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-51c4f80a.js:42620:11)
    at Parser.onParseError (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-51c4f80a.js:42542:13)
    at Tokenizer._err (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-19c40c50.js:1155:89)
    at Tokenizer._stateTagOpen (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-19c40c50.js:1983:26)
    at Tokenizer._callState (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-19c40c50.js:1534:22)
    at Tokenizer._runParsingLoop (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-19c40c50.js:1179:22)
    at Tokenizer.write (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-19c40c50.js:1204:14)
    at Function.parse (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-19c40c50.js:4896:26)
    at parse (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-19c40c50.js:8063:19)
    at traverseHtml (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-51c4f80a.js:42539:17)
```

## After
```
$ yarn build
yarn run v1.22.19
$ tsc && vite build
vite v3.2.3 building for production...
✓ 0 modules transformed.
[vite:build-html] ejs:10
    8|   </head>
    9|   <body>
 >> 10|     <% something_invalid_content %>
    11|     <div id="app"></div>
    12|     <script type="module" src="/src/main.ts"></script>
    13|   </body>

something_invalid_content is not defined
file: /home/yoichi/proj/vite-plugin-ejs-error-sample/index.html
error during build:
ReferenceError: ejs:10
    8|   </head>
    9|   <body>
 >> 10|     <% something_invalid_content %>
    11|     <div id="app"></div>
    12|     <script type="module" src="/src/main.ts"></script>
    13|   </body>

something_invalid_content is not defined
    at eval (eval at compile (/home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/ejs/lib/ejs.js:673:12), <anonymous>:12:8)
    at anonymous (/home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/ejs/lib/ejs.js:703:17)
    at Object.exports.render (/home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/ejs/lib/ejs.js:425:37)
    at transform (/home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite-plugin-ejs/index.js:36:38)
    at applyHtmlTransforms (file:///home/yoichi/proj/vite-plugin-ejs-error-sample/node_modules/vite/dist/node/chunks/dep-51c4f80a.js:43077:27)
```

